### PR TITLE
Remove generic error handler in rammerhead

### DIFF
--- a/rammerhead/src/util/addMoreErrorGuards.js
+++ b/rammerhead/src/util/addMoreErrorGuards.js
@@ -29,9 +29,5 @@ process.on('uncaughtException', (err) => {
     ) {
         // crash avoided!
         console.error('Avoided crash:' + err.message);
-    } else {
-        // probably a TypeError or something important
-        console.error('About to throw: ' + err.message);
-        //throw new Error(err.message);
     }
 });


### PR DESCRIPTION
This PR removes the generic else case in addMoreErrorGuards.js, it's completely unnecessary, as JS should throw it's own error if it's critical, it doesn't need to be handled here.